### PR TITLE
Remove jQuery / Enable Pimcore 6.3 compatibility

### DIFF
--- a/src/WorkflowGui/Resources/public/js/pimcore/workflow/item.js
+++ b/src/WorkflowGui/Resources/public/js/pimcore/workflow/item.js
@@ -209,9 +209,9 @@ pimcore.plugin.workflow.item = Class.create({
     },
 
     getSettingsPanel: function () {
-        var data = this.data.hasOwnProperty('marking_store') ? this.data.marking_store.arguments : [];
+        var markingStoreArgumentsData = this.data.hasOwnProperty('marking_store') ? this.data.marking_store.arguments : [];
         var markingStoreArguments = new Ext.data.ArrayStore({
-            data: data.map(function(value, index) {
+            data: markingStoreArgumentsData.map(function(value, index) {
                 return [[value]];
             }),
             fields: [

--- a/src/WorkflowGui/Resources/public/js/pimcore/workflow/item.js
+++ b/src/WorkflowGui/Resources/public/js/pimcore/workflow/item.js
@@ -209,8 +209,9 @@ pimcore.plugin.workflow.item = Class.create({
     },
 
     getSettingsPanel: function () {
+        var data = this.data.hasOwnProperty('marking_store') ? this.data.marking_store.arguments : [];
         var markingStoreArguments = new Ext.data.ArrayStore({
-            data: $.map(this.data.hasOwnProperty('marking_store') ? this.data.marking_store.arguments : [], function (value, index) {
+            data: data.map(function(value, index) {
                 return [[value]];
             }),
             fields: [


### PR DESCRIPTION
Pimcore removed jQuery in the backend in https://github.com/pimcore/pimcore/pull/5222
To be able to use this plugin this plugin replaces the single jQuery usage by native JS.