### PR TITLE
Custom Layout IDs can be alphanumeric

### DIFF
--- a/src/WorkflowGui/Resources/public/js/pimcore/workflow/place_permission.js
+++ b/src/WorkflowGui/Resources/public/js/pimcore/workflow/place_permission.js
@@ -76,7 +76,7 @@ pimcore.plugin.workflow.place_permission = Class.create({
                 this.getPermissionCheckbox(permission, 'properties'),
                 this.getPermissionCheckbox(permission, 'modify'),
                 {
-                    xtype: 'numberfield',
+                    xtype: 'textfield',
                     name: 'objectLayout',
                     value: permission.get('objectLayout'),
                     fieldLabel: t('workflow_place_permission_object_layout')


### PR DESCRIPTION
This PR enables the user to be able to enter alphanumeric ID of a custom layout, for example "abc".