### PR TITLE
[Visualization] Show message when graphviz is not installed

### DIFF
--- a/src/WorkflowGui/Controller/WorkflowController.php
+++ b/src/WorkflowGui/Controller/WorkflowController.php
@@ -333,7 +333,6 @@ class WorkflowController extends AdminController
         $this->isGrantedOr403();
 
         try {
-
             $image = $this->getVisualization($request->get('workflow'), 'png');
 
             $response = new Response();
@@ -363,9 +362,9 @@ class WorkflowController extends AdminController
      */
     private function getVisualization($workflow, $format) {
         try {
-            $dotExecutable = Console::getExecutable('dot');
+            $dotExecutable = Console::getExecutable('dot', true);
         } catch(\Exception $e) {
-            return new Response('Please install graphviz to visualize workflows');
+            throw new \Exception('Please install graphviz to visualize workflows');
         }
 
         $cliCommand = '"'.Console::getPhpCli().'" "'.PIMCORE_PROJECT_ROOT . '/bin/console" pimcore:workflow:dump '.$workflow.' | "'.$dotExecutable.'" -T'.$format;


### PR DESCRIPTION
Currently if you call `<Pimcore Host>/admin/workflow/visualize_image?workflow=<Workflow Name>` with graphviz not being installed you get the error `strlen() expects parameter 1 to be string, null given`. This comes from https://github.com/YouweGit/pimcore-workflow-gui/blob/540c5384ea062cdfd1fe9cd9d5a3eaa4235b424e/src/WorkflowGui/Controller/WorkflowController.php#L344 resp the Catch-Throwable-Block.
The acutal reason is hidden and the user does not know how to get the visualization working. This PR changes this problem and shows `Please install graphviz to visualize workflows` when graphviz is not installed.