### PR TITLE
Fixed a typo in the places data source which leads to wrong places la…

### DIFF
--- a/src/WorkflowGui/Resources/public/js/pimcore/workflow/item.js
+++ b/src/WorkflowGui/Resources/public/js/pimcore/workflow/item.js
@@ -118,7 +118,7 @@ pimcore.plugin.workflow.item = Class.create({
         places = Object.keys(places).map(function (objectKey, index) {
             var place = places[objectKey];
             place['id'] = objectKey;
-            place['label'] = (place.label && place.label.lenght > 0)
+            place['label'] = (place.label && place.label.length > 0)
                 ? t(place.label)
                 : objectKey;
 


### PR DESCRIPTION
Currently if you open a workflow and save it again, the label of that place will be replaced with the objectkey of that place because of a typo.