### PR TITLE
Fix: force environment in workflow visualization console command

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
     }
   ],
   "require": {
+    "php": "^8.0",
     "pimcore/pimcore": "^10.0.0"
   },
   "autoload": {

--- a/src/WorkflowGui/Repository/WorkflowRepository.php
+++ b/src/WorkflowGui/Repository/WorkflowRepository.php
@@ -23,7 +23,7 @@ use Youwe\Pimcore\WorkflowGui\Resolver\ConfigFileResolverInterface;
 
 class WorkflowRepository implements WorkflowRepositoryInterface
 {
-    protected $configFileResolver;
+    protected ConfigFileResolverInterface $configFileResolver;
 
     public function __construct(ConfigFileResolverInterface $configFileResolver)
     {

--- a/src/WorkflowGui/Resolver/ConfigFileResolver.php
+++ b/src/WorkflowGui/Resolver/ConfigFileResolver.php
@@ -20,7 +20,7 @@ use Symfony\Component\Filesystem\Filesystem;
 
 class ConfigFileResolver implements ConfigFileResolverInterface
 {
-    protected $configFile;
+    protected string $configFile;
 
     public function __construct(string $configFile)
     {

--- a/src/WorkflowGui/Resources/config/services.yml
+++ b/src/WorkflowGui/Resources/config/services.yml
@@ -14,6 +14,7 @@ services:
         arguments:
             - '@Youwe\Pimcore\WorkflowGui\Repository\WorkflowRepository'
             - '@Youwe\Pimcore\WorkflowGui\Resolver\ConfigFileResolver'
+            - '@kernel'
         tags:
             - { name: controller.service_arguments }
         calls:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | yes, service names changed (in separate commit)
| Deprecations? | no
| Fixed tickets | n/a

fix: force environment in workflow visualization console command

Error: The workflow visualization didn't work on our client-acceptance environment
Caused by: Wrong Pimcore environment was used in the command used to build the visualization
Resolved by: Explicitly passing the enviroment in the console command call

---
I also have a cherry-pick to be compatible with the Pimcore 6 version. There is a pimcore-6 branch in this repo, but that one is terribly out of date. Probably we can revive that branch?

https://github.com/youwe-petervanderwal/pimcore-workflow-gui/commit/6d11954c0ba6be49f9b26a499440270a8efb6e8a#diff-38e07c750eacf53f18aa734e06a1dcb838e558ee18c60210883aeff0ffad25b0 