### PR TITLE
fix: force environment in workflow visualization console command

### DIFF
--- a/src/WorkflowGui/Controller/WorkflowController.php
+++ b/src/WorkflowGui/Controller/WorkflowController.php
@@ -21,10 +21,11 @@ use Pimcore\Bundle\CoreBundle\DependencyInjection\Configuration;
 use Pimcore\Model\User;
 use Pimcore\Tool\Console;
 use Symfony\Component\Config\Definition\Processor;
-use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\HttpKernel\KernelInterface;
+use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 use Symfony\Component\Yaml\Yaml;
 use Youwe\Pimcore\WorkflowGui\Repository\WorkflowRepositoryInterface;
 use Youwe\Pimcore\WorkflowGui\Resolver\ConfigFileResolver;
@@ -42,13 +43,23 @@ class WorkflowController extends AdminController
     protected $configResolver;
 
     /**
+     * @var KernelInterface
+     */
+    protected $kernel;
+
+    /**
      * @param WorkflowRepositoryInterface $repository
      * @param ConfigFileResolver          $configFileResolver
+     * @param KernelInterface             $kernel
      */
-    public function __construct(WorkflowRepositoryInterface $repository, ConfigFileResolver $configFileResolver)
-    {
+    public function __construct(
+        WorkflowRepositoryInterface $repository,
+        ConfigFileResolver $configFileResolver,
+        KernelInterface $kernel
+    ) {
         $this->repository = $repository;
         $this->configResolver = $configFileResolver;
+        $this->kernel = $kernel;
     }
 
     /**
@@ -367,7 +378,8 @@ class WorkflowController extends AdminController
             throw new \Exception('Please install graphviz to visualize workflows');
         }
 
-        $cliCommand = '"'.Console::getPhpCli().'" "'.PIMCORE_PROJECT_ROOT . '/bin/console" pimcore:workflow:dump '.$workflow.' | "'.$dotExecutable.'" -T'.$format;
+        $environment = $this->kernel->getEnvironment();
+        $cliCommand = '"'.Console::getPhpCli().'" "'.PIMCORE_PROJECT_ROOT . '/bin/console" --env="'.$environment.'" pimcore:workflow:dump '.$workflow.' | "'.$dotExecutable.'" -T'.$format;
         return Console::exec($cliCommand);
     }
 }

--- a/src/WorkflowGui/Resources/config/services.yml
+++ b/src/WorkflowGui/Resources/config/services.yml
@@ -14,5 +14,6 @@ services:
         arguments:
             - '@Youwe\Pimcore\WorkflowGui\Repository\WorkflowRepository'
             - '@Youwe\Pimcore\WorkflowGui\Resolver\ConfigFileResolver'
+            - '@kernel'
         tags:
             - { name: controller.service_arguments }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | n/a

Error: The workflow visualization didn't work on our client-acceptance environment
Caused by: Wrong Pimcore environment was used in the command used to build the visualization
Resolved by: Explicitly passing the enviroment in the console command call

Cherry-picks 647b72f7cfeb394d70eb11ce809acdad9d87549c to Pimcore 6
See also https://github.com/YouweGit/pimcore-workflow-gui/pull/61 
