### PR TITLE
Remove trailing comma in line 42

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
       ]
     },
     "branch-alias": {
-      "dev-master": "2.0-dev",
+      "dev-master": "2.0-dev"
     }
   }
 }


### PR DESCRIPTION
To fix this installing from the repo:

Skipped branch master, "c8355d6e4637cba597e4c79714e95677d48903bf:composer.json" does not contain valid JSON
Parse error on line 42:
...er": "2.0-dev",    }  }}
---------------------^
Expected: 'STRING' - It appears you have an extra trailing comma

| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | yes/no
| Fixed tickets | #...   <!-- #-prefixed issue number(s), if any -->

<!--
Write a short README entry for your feature/bugfix here (replace this comment block.)
This will help people understand your PR and can be used as a start of the Doc PR.
-->
