### PR TITLE
chore: Make menuitem icon diapositive

### DIFF
--- a/src/WorkflowGui/Resources/public/js/pimcore/startup.js
+++ b/src/WorkflowGui/Resources/public/js/pimcore/startup.js
@@ -29,7 +29,7 @@ pimcore.plugin.WorkflowGuiBundle = Class.create(pimcore.plugin.admin, {
         if(user.isAllowed('workflow_gui') && perspectiveCfg.inToolbar('settings.workflow_gui')) {
             var settingsMenu = new Ext.Action({
                 text: t('workflows'),
-                iconCls: 'worklfow_gui_nav_icon_workflow',
+                icon: '/bundles/pimcoreadmin/img/flat-white-icons/workflow.svg',
                 handler : this.showWorkflows
             });
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no

Because GUI of Pimcore has been new icons, this bundle didnt upgraded to that new icons
