### PR TITLE
Don't unset visibleInHeader in place configuration.

### DIFF
--- a/src/WorkflowGui/Controller/WorkflowController.php
+++ b/src/WorkflowGui/Controller/WorkflowController.php
@@ -268,7 +268,7 @@ class WorkflowController extends AdminController
                     }
                 }
                 foreach ($placeConfig as $placeConfigKey => $value) {
-                    if (!$value) {
+                    if (!$value && !in_array($placeConfigKey, ['visibleInHeader'])) {
                         unset($placeConfig[$placeConfigKey]);
                     }
                 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no

After migration Workflow to Symfony (since Pimcore 5.6) option "visibleInHeader" set true by default: https://github.com/pimcore/pimcore/blob/5.8/bundles/CoreBundle/DependencyInjection/Configuration.php#L1063

As reason, On Workflow GUI Place settings unchecking option isn't stored, because they are unset in Controller action and no way to change this parameter. In fix, I've just added skipping unset for  'visibleInHeader'.

Fix is relevant for 2.x version too. "visibleInHeader" set true by default in Pimcores 6.x and 10.x too.

Please review,
 