### PR TITLE
Fix Youwe\Pimcore\WorkflowGui\Repository\WorkflowRepository::loadConfig(): Return value must be of type array, null returned

### DIFF
--- a/src/WorkflowGui/Repository/WorkflowRepository.php
+++ b/src/WorkflowGui/Repository/WorkflowRepository.php
@@ -72,7 +72,7 @@ class WorkflowRepository implements WorkflowRepositoryInterface
     {
         return Yaml::parse(
             file_get_contents($this->configFileResolver->getConfigPath())
-        );
+        ) ?? [];
     }
 
     protected function storeConfig(array $config): void


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  |no
| BC breaks?    | no
| Deprecations? |no

Directly after fresh installation
https://github.com/YouweGit/pimcore-workflow-gui/blob/dd74727e16622af4762ab56bd723085141bb6b72/src/WorkflowGui/Repository/WorkflowRepository.php#L74
returns an empty string.
`Yaml::parse("")` returns `null`.

But https://github.com/YouweGit/pimcore-workflow-gui/blob/dd74727e16622af4762ab56bd723085141bb6b72/src/WorkflowGui/Repository/WorkflowRepository.php#L71 requires that an array gets returned. Thus you cannot even open the workflow configuration panel but get the error
`Youwe\Pimcore\WorkflowGui\Repository\WorkflowRepository::loadConfig(): Return value must be of type array, null returned`