### PR TITLE
allow numbers for ids and names, check for existing array-keys

### DIFF
--- a/src/WorkflowGui/Controller/WorkflowController.php
+++ b/src/WorkflowGui/Controller/WorkflowController.php
@@ -260,15 +260,15 @@ class WorkflowController extends UserAwareController
 
                     if (isset($transitionConfig['options']['notes']['additionalFields'])) {
                         foreach ($transitionConfig['options']['notes']['additionalFields'] as &$additionalField) {
-                            if (!$additionalField['setterFn']) {
+                            if (isset($additionalField['setterFn']) && !$additionalField['setterFn']) {
                                 unset ($additionalField['setterFn']);
                             }
 
-                            if (!$additionalField['title']) {
+                            if (isset($additionalField['title']) && !$additionalField['title']) {
                                 unset ($additionalField['title']);
                             }
 
-                            if (!$additionalField['required']) {
+                            if (isset($additionalField['required']) && !$additionalField['required']) {
                                 unset ($additionalField['required']);
                             }
                         }

--- a/src/WorkflowGui/Resources/public/js/pimcore/workflow/global_action.js
+++ b/src/WorkflowGui/Resources/public/js/pimcore/workflow/global_action.js
@@ -175,7 +175,13 @@ pimcore.plugin.workflow.global_action = Class.create({
                     value: globalAction.getId(),
                     fieldLabel: t('workflow_global_action_id'),
                     allowBlank: false,
-                    regex: /^[a-zA-Z_]+$/
+                    regex: /^[a-zA-Z_0-9]+$/
+                },
+                {
+                    xtype: 'textfield',
+                    name: 'label',
+                    value: globalAction.get('label'),
+                    fieldLabel: t('workflow_label'),
                 },
                 {
                     xtype: 'textfield',

--- a/src/WorkflowGui/Resources/public/js/pimcore/workflow/item.js
+++ b/src/WorkflowGui/Resources/public/js/pimcore/workflow/item.js
@@ -337,7 +337,7 @@ pimcore.plugin.workflow.item = Class.create({
                     value: this.id,
                     fieldLabel: t('workflow_name'),
                     allowBlank: false,
-                    regex: /^[a-zA-Z_]+$/
+                    regex: /^[a-zA-Z_0-9]+$/
                 },
                 {
                     xtype: 'checkbox',

--- a/src/WorkflowGui/Resources/public/js/pimcore/workflow/place.js
+++ b/src/WorkflowGui/Resources/public/js/pimcore/workflow/place.js
@@ -103,7 +103,7 @@ pimcore.plugin.workflow.place = Class.create({
                     value: place.getId(),
                     fieldLabel: t('workflow_place_id'),
                     allowBlank: false,
-                    regex: /^[a-zA-Z_]+$/
+                    regex: /^[a-zA-Z_0-9]+$/
                 },
                 {
                     xtype: 'textfield',

--- a/src/WorkflowGui/Resources/public/js/pimcore/workflow/transition.js
+++ b/src/WorkflowGui/Resources/public/js/pimcore/workflow/transition.js
@@ -226,7 +226,7 @@ pimcore.plugin.workflow.transition = Class.create({
                     value: transition.getId(),
                     fieldLabel: t('workflow_transition_id'),
                     allowBlank: false,
-                    regex: /^[a-zA-Z_]+$/
+                    regex: /^[a-zA-Z_0-9]+$/
                 },
 
                 {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #... 

added numbers to id and name fields' regex
check for array-keys exists before validation in sanitizing method
add label property to global actions